### PR TITLE
using MacroTools.postwalk

### DIFF
--- a/src/SourceWalk.jl
+++ b/src/SourceWalk.jl
@@ -3,7 +3,7 @@ module SourceWalk
 using Reexport
 
 @reexport using MacroTools
-using MacroTools: @forward, striplines
+using MacroTools: @forward, striplines, postwalk
 using DataStructures
 
 export sourcewalk


### PR DESCRIPTION
Currently `sourcewalk` and `textwalk` causes an error because of this.